### PR TITLE
NEST-491: Use build-and-test-orchard-core for the CI build in DotNest Core SDK

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,7 @@ jobs:
     name: Build and Test
     uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
-      timeout-minutes: 20
-      build-create-binary-log: "true"
-      blame-hang-timeout: "5m"
+      timeout-minutes: 5
 
   spelling:
     name: Spelling

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,6 @@ jobs:
     name: Build and Test
     uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
-      machine-types: "['gitrunners-ubuntu-2204-x64-4vcpu']"
       timeout-minutes: 20
       build-create-binary-log: "true"
       blame-hang-timeout: "5m"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,9 +10,12 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-dotnet.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
-      timeout-minutes: 5
+      machine-types: "['gitrunners-ubuntu-2204-x64-4vcpu']"
+      timeout-minutes: 20
+      build-create-binary-log: "true"
+      blame-hang-timeout: "5m"
 
   spelling:
     name: Spelling

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,12 +10,9 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-dotnet.yml@dev
     with:
-      machine-types: "['gitrunners-ubuntu-2204-x64-4vcpu']"
-      timeout-minutes: 20
-      build-create-binary-log: "true"
-      blame-hang-timeout: "5m"
+      timeout-minutes: 5
 
   spelling:
     name: Spelling


### PR DESCRIPTION
[NEST-491](https://lombiq.atlassian.net/browse/NEST-491)
Fixes #35

[NEST-491]: https://lombiq.atlassian.net/browse/NEST-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ